### PR TITLE
Remove ghostly systemtray

### DIFF
--- a/src/main/java/com/github/cypher/Main.java
+++ b/src/main/java/com/github/cypher/Main.java
@@ -69,21 +69,21 @@ public class Main extends Application {
 
 		// Only hide close the main window if system tray is enabled and supported.
 		primaryStage.setOnCloseRequest(event -> {
-			if (useSyetemTray()) {
+			if (useSystemTray()) {
 				primaryStage.close();
 			} else {
 				exit();
 			}
 		});
-		if (useSyetemTray()) {
+		if (useSystemTray()) {
 			addTrayIcon(primaryStage);
 		}
 
 		primaryStage.show();
 	}
 
-	private boolean useSyetemTray() {
-		return (settings.setUseSystemTray() && SystemTray.get() != null);
+	private boolean useSystemTray() {
+		return (settings.getUseSystemTray() && SystemTray.get() != null);
 	}
 
 	private void addTrayIcon(Stage primaryStage) {

--- a/src/main/java/com/github/cypher/Main.java
+++ b/src/main/java/com/github/cypher/Main.java
@@ -83,7 +83,7 @@ public class Main extends Application {
 	}
 
 	private boolean useSyetemTray() {
-		return ( SystemTray.get() != null && settings.setUseSystemTray());
+		return (settings.setUseSystemTray() && SystemTray.get() != null);
 	}
 
 	private void addTrayIcon(Stage primaryStage) {

--- a/src/main/java/com/github/cypher/settings/Settings.java
+++ b/src/main/java/com/github/cypher/settings/Settings.java
@@ -11,7 +11,7 @@ public interface Settings {
 	boolean getSaveSession();
 	void setSaveSession(boolean saveSession);
 
-	boolean setUseSystemTray();
+	boolean getUseSystemTray();
 	void setUseSystemTray(boolean exitToSystemTray);
 
 	// If control + enter should be used for sending messages (if false only enter is needed)

--- a/src/main/java/com/github/cypher/settings/TOMLSettings.java
+++ b/src/main/java/com/github/cypher/settings/TOMLSettings.java
@@ -104,7 +104,7 @@ public class TOMLSettings implements Settings {
 	}
 
 	@Override
-	public synchronized boolean setUseSystemTray() {
+	public synchronized boolean getUseSystemTray() {
 		return settingsData.useSystemTray;
 	}
 


### PR DESCRIPTION
Not initializing the systemtray if the setting is turned off makes the ghostly systemtray menu on GTK go away.