### PR TITLE
Encode outgoing JSON data as UTF-8

### DIFF
--- a/src/main/java/com/github/cypher/sdk/api/Util.java
+++ b/src/main/java/com/github/cypher/sdk/api/Util.java
@@ -74,7 +74,7 @@ public final class Util {
 
 			// Push Data
 			DataOutputStream writer = new DataOutputStream(conn.getOutputStream());
-			writer.writeBytes(data.toString());
+			writer.write(data.toString().getBytes("UTF-8"));
 			writer.flush();
 			writer.close();
 		}


### PR DESCRIPTION
Fixes issue where the user was unable to send complex character.
This was due to Java strings being encoded as UTF-16.