### PR TITLE
Recursively load scrollback history

### DIFF
--- a/src/main/java/com/github/cypher/gui/root/roomcollection/room/chat/ChatPresenter.java
+++ b/src/main/java/com/github/cypher/gui/root/roomcollection/room/chat/ChatPresenter.java
@@ -102,11 +102,12 @@ public class ChatPresenter {
 		if(isLoadingHistory) { return; }
 
 		Room room = client.getSelectedRoom();
+		ScrollBar scrollBar = eventListScrollBar;
 
 		if(room != null &&
-		   eventListScrollBar != null &&
+		   scrollBar != null &&
 		   // Is the scroll bar at the top?
-		   eventListScrollBar.getValue() == eventListScrollBar.getMin()) {
+		   scrollBar.getValue() == scrollBar.getMin()) {
 
 			// Save current scroll bar position
 			scrollTo = backendListForEventView.getList().size() - 1;
@@ -122,7 +123,7 @@ public class ChatPresenter {
 
 					if(more) {
 						// If not all history is loaded, run method again
-						Platform.runLater(this::checkMessageHistoryDemand);
+						checkMessageHistoryDemand();
 					}
 				} catch (SdkException e) {
 					isLoadingHistory = false;

--- a/src/main/java/com/github/cypher/gui/root/roomcollection/room/chat/ChatPresenter.java
+++ b/src/main/java/com/github/cypher/gui/root/roomcollection/room/chat/ChatPresenter.java
@@ -57,7 +57,7 @@ public class ChatPresenter {
 
 	private final ChangeListener<? super Number> scrollListener = (observable, oldValue, newValue) -> checkMessageHistoryDemand();
 
-	private boolean isLoadingHistory = false;
+	private volatile boolean isLoadingHistory = false;
 
 	@FXML
 	private TextArea messageBox;
@@ -118,14 +118,14 @@ public class ChatPresenter {
 					// Try to load more history
 					boolean more = room.loadEventHistory(HISTORY_CHUNK_SIZE);
 
-					Platform.runLater(() -> isLoadingHistory = false);
+					isLoadingHistory = false;
 
 					if(more) {
 						// If not all history is loaded, run method again
 						Platform.runLater(this::checkMessageHistoryDemand);
 					}
 				} catch (SdkException e) {
-					Platform.runLater(() -> isLoadingHistory = false);
+					isLoadingHistory = false;
 					System.out.printf("SdkException when trying to get room history: %s\n", e);
 				}
 			});

--- a/src/main/java/com/github/cypher/model/Room.java
+++ b/src/main/java/com/github/cypher/model/Room.java
@@ -167,9 +167,9 @@ public class Room {
 
 	}
 
-	public void loadEventHistory(Integer limit) throws SdkException {
+	public boolean loadEventHistory(Integer limit) throws SdkException {
 		try {
-			sdkRoom.getEventHistory(limit);
+			return sdkRoom.getEventHistory(limit);
 		} catch(RestfulHTTPException | IOException e) {
 			throw new SdkException(e);
 		}

--- a/src/main/java/com/github/cypher/sdk/Room.java
+++ b/src/main/java/com/github/cypher/sdk/Room.java
@@ -134,7 +134,14 @@ public class Room {
 		parseStateEvents(data);
 	}
 
-	public void getEventHistory(Integer limit) throws RestfulHTTPException, IOException {
+	/**
+	 * Try to download older events from the room event log
+	 * @param limit The maximum amount of events to get
+	 * @return false if all history is loaded, otherwise true
+	 * @throws RestfulHTTPException
+	 * @throws IOException
+	 */
+	public boolean getEventHistory(Integer limit) throws RestfulHTTPException, IOException {
 		if(earliestBatch == null) {
 			throw new IOException("sdk.Room.getHistory(...) called before first sdk.Client.sync(...)");
 		}
@@ -154,12 +161,18 @@ public class Room {
 
 			JsonArray chunk = data.get("chunk").getAsJsonArray();
 
+			if (chunk.size() == 0) {
+				return false;
+			}
+
 			for(JsonElement eventElement : chunk) {
 				if(eventElement.isJsonObject()) {
 					parseEventData(eventElement.getAsJsonObject());
 				}
 			}
 		}
+
+		return true;
 	}
 
 	private void parseBasicPropertiesData(JsonObject data) {


### PR DESCRIPTION
After loading scrollback history, check again weather more history is wanted.
This resolves an issue when the user would scroll up too fast and history would stop loading.
___
##### Known issues:
  - History isn't loaded for the default selected room on application start