### PR TITLE
Sort events by `age` not `origin_server_ts`

### DIFF
--- a/src/main/java/com/github/cypher/model/Event.java
+++ b/src/main/java/com/github/cypher/model/Event.java
@@ -3,11 +3,13 @@ package com.github.cypher.model;
 public class Event {
 	private final String eventId;
 	private final long originServerTimeStamp;
+	private final long timeStamp;
 	private final User sender;
 
 	Event(Repository<User> repo,com.github.cypher.sdk.Event sdkEvent){
 		eventId = sdkEvent.getEventId();
 		originServerTimeStamp = sdkEvent.getOriginServerTs();
+		timeStamp = sdkEvent.getUnsignedTimeStamp();
 		sender = repo.get(sdkEvent.getSender().getId());
 	}
 
@@ -17,6 +19,10 @@ public class Event {
 
 	public long getOriginServerTimeStamp() {
 		return originServerTimeStamp;
+	}
+
+	public long getTimeStamp() {
+		return timeStamp;
 	}
 
 	public User getSender() {

--- a/src/main/java/com/github/cypher/model/Room.java
+++ b/src/main/java/com/github/cypher/model/Room.java
@@ -97,7 +97,7 @@ public class Room {
 				events.add(new Message(repo, (com.github.cypher.sdk.Message)event));
 			}
 		}
-		events.sort((a, b) -> (int)(a.getOriginServerTimeStamp() - b.getOriginServerTimeStamp()));
+		events.sort((a, b) -> (int)(a.getTimeStamp() - b.getTimeStamp()));
 
 		sdkRoom.addEventListener(change -> {
 			if (change.wasAdded()) {
@@ -111,10 +111,10 @@ public class Room {
 					return;
 				}
 
-				long timestamp = sdkEvent.getOriginServerTs();
+				long timestamp = sdkEvent.getUnsignedTimeStamp();
 
 				for(int i = 0; i < events.size(); i++) {
-					if(timestamp < events.get(i).getOriginServerTimeStamp()) {
+					if(timestamp < events.get(i).getTimeStamp()) {
 						events.add(i, event);
 						return;
 					}

--- a/src/main/java/com/github/cypher/sdk/Event.java
+++ b/src/main/java/com/github/cypher/sdk/Event.java
@@ -10,6 +10,7 @@ public class Event {
 	private final String eventId;
 	private final String type;
 	private final int age;
+	private final long unsignedTimeStamp;
 
 	Event(ApiLayer api, long originServerTs, User sender, String eventId, String type, int age) {
 		this.api            = api;
@@ -18,11 +19,13 @@ public class Event {
 		this.eventId        = eventId;
 		this.type           = type;
 		this.age            = age;
+		unsignedTimeStamp = System.currentTimeMillis() - age;
 	}
 
-	public long   getOriginServerTs(){ return originServerTs; }
-	public User   getSender()         { return sender; }
-	public String getEventId()        { return eventId; }
-	public String getType()           { return type; }
-	public int    getAge()            { return age; }
+	public long   getOriginServerTs()   { return originServerTs; }
+	public User   getSender()           { return sender; }
+	public String getEventId()          { return eventId; }
+	public String getType()             { return type; }
+	public int    getAge()              { return age; }
+	public long   getUnsignedTimeStamp(){ return unsignedTimeStamp; }
 }


### PR DESCRIPTION
This solution will ideally sorts events in the proper order.
The drawback is that the `age` is not always verifiable by the home server.